### PR TITLE
fix failed tests when running yarn test

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,3 @@
+export default [
+  {},
+];


### PR DESCRIPTION
Having installed dependencies with yarn `yarn install` (or pnpm) running the tests `yarn test` leads to errors 

```ssh
$ yarn test
yarn run v1.22.4
$ jest
 FAIL  test/component.spec.js
  ● Test suite failed to run

    Could not find svelte.config.js

      at exports.getSvelteConfig (node_modules/svelte-jester/src/svelteconfig.js:13:11)
      at Object.process (node_modules/svelte-jester/src/transformer.js:9:24)
      at ScriptTransformer.transformSource (node_modules/@jest/transform/build/ScriptTransformer.js:481:35)
      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:586:40)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:624:25)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.955s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Adding a default `svelte.config.js` file solves this problem